### PR TITLE
Enable rpath on OS X when the CMake version supports it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ endif()
 if(POLICY CMP0015)
 	cmake_policy(SET CMP0015 OLD)
 endif()
+# see https://cmake.org/cmake/help/latest/policy/CMP0042.html
+if(POLICY CMP0042)
+	# Enable MACOSX_RPATH by default.
+	cmake_policy(SET CMP0042 NEW)
+endif()
 
 include(CheckCXXCompilerFlag)
 


### PR DESCRIPTION
CMake policy `CMP0042` changes the default value of the `MACOSX_RPATH` target property to `TRUE`, therefore setting the directory portion of the `install_name` field of a shared library to be `@rpath` on OS X.

Without the `CMP0042` set to `NEW`, when using yaml-cpp as a shared library on OS X, we have been seeing runtime errors such as the following:

```
dyld: Library not loaded: libyaml-cpp.0.5.dylib
  Referenced from: /path/to/executable-linked-to-libyaml-cpp
  Reason: image not found
```